### PR TITLE
Make milestone number filter optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ args
     .option('-t, --token [github_api_token]', 'Your GitHub API token', process.env.GITHUB_API_TOKEN)
     .option('-o, --owner [repo_owner]', 'The GitHub repo owner - username or org name', process.env.REPO_OWNER)
     .option('-r, --repo [repo_name]', 'The GitHub repo name', process.env.REPO_NAME)
-    .option('-m, --milestone [number]', 'The repo milestone number (from the URL)', process.env.REPO_MILESTONE)
+    .option('-m, --milestone [number]', '(Optional) repo milestone number filter (from the GitHub URL)', process.env.REPO_MILESTONE)
     .parse(process.argv)
 
 if (!args.token) {

--- a/index.js
+++ b/index.js
@@ -31,10 +31,11 @@ if (!args.repo) {
     throw new Error('Missing GitHub repo name!')
 }
 if (!args.milestone) {
-    throw new Error('Missing GitHub repo milestone number!')
+    console.error('No milestone number provided - all issues will be included.')
 }
 
-const URL = `https://api.github.com/repos/${args.owner}/${args.repo}/issues?milestone=${args.milestone}`
+const milestoneFilter = args.milestone ? `milestone=${args.milestone}` : ''
+const URL = `https://api.github.com/repos/${args.owner}/${args.repo}/issues?${milestoneFilter}`
 
 log(`> GET ${URL}`)
 request({


### PR DESCRIPTION
This PR removes the requirement to specify a milestone number filter. If not present, all issues in the specified repo will be retrieved.