### PR TITLE
Add ability to include issue body

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ $ node index.js --help
     -t, --token [github_api_token]  Your GitHub API token
     -o, --owner [repo_owner]        The GitHub repo owner - username or org name
     -r, --repo [repo_name]          The GitHub repo name
-    -m, --milestone [number]        The repo milestone number (from the URL)
+    -m, --milestone [number]        (Optional) repo milestone number filter (from the GitHub URL)
+    --no-body                       Excludes the Issue body text
     -h, --help                      output usage information
 ```
 **Note:** For security reasons, it is **highly recommended** to avoid passing the API token on the command line - use an environment variable instead~

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ args
     .option('-o, --owner [repo_owner]', 'The GitHub repo owner - username or org name', process.env.REPO_OWNER)
     .option('-r, --repo [repo_name]', 'The GitHub repo name', process.env.REPO_NAME)
     .option('-m, --milestone [number]', '(Optional) repo milestone number filter (from the GitHub URL)', process.env.REPO_MILESTONE)
+    .option('--no-body', 'Excludes the Issue body text')
     .parse(process.argv)
 
 if (!args.token) {
@@ -80,10 +81,12 @@ function processIssuesJson(json) {
         let issueNum = `#${issue.number}`
         let cardTitle = issue.title
         let repoName = args.repo
+        let issueBody = issue.body
         let issueData = {
             number: issue.number,
             title: issue.title,
-            repo: repoName
+            repo: repoName,
+            body: issueBody
         }
         newIssues.push(issueData)
     })
@@ -126,7 +129,11 @@ function createPdf(issues) {
         // back to regular opacity for header text
         pdfDoc.fillOpacity(1.0).fill('black')
         pdfDoc.font('Helvetica').fontSize(36).text(`${issueNum}: ${repoName}`).moveDown() // header title
-        pdfDoc.font('Helvetica').fontSize(72).text(cardTitle) // main text
+        pdfDoc.font('Helvetica').fontSize(72).lineGap(1).text(cardTitle) // main text
+        pdfDoc.fontSize(8).moveDown()
+        if (args.body) {
+            pdfDoc.font('Helvetica').fontSize(32).text(issue.body, {height: 250, ellipsis: '...'})
+        }
         pdfDoc.rect(borderStartX, borderStartY, borderEndX, borderEndY).stroke() // main card border box
         pdfDoc.save()
     })


### PR DESCRIPTION
This PR includes the issue body by default, and provides a command-line argument which can be used to exclude the Issue body text if desired.