### PR TITLE
Cleanup issue body

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const PDFKit = require('pdfkit')
 const request = require('request')
 const fs = require('fs')
 const args = require('commander')
+const removeMd = require('remove-markdown')
 
 const os = require('os')
 const packageInfo = require('./package.json')
@@ -82,6 +83,8 @@ function processIssuesJson(json) {
         let cardTitle = issue.title
         let repoName = args.repo
         let issueBody = issue.body
+        issueBody = issueBody.replace(/\r/g, '') // pdfkit doesn't handle \r properly (\n is ok)
+        issueBody = removeMd(issueBody, { stripListLeaders: false })
         let issueData = {
             number: issue.number,
             title: issue.title,

--- a/package-lock.json
+++ b/package-lock.json
@@ -669,6 +669,11 @@
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
       "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
+    "remove-markdown": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/remove-markdown/-/remove-markdown-0.2.2.tgz",
+      "integrity": "sha1-ZrDO66n7d8qWNrsbAwfOIaMqEqY="
+    },
     "request": {
       "version": "2.83.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "commander": "^2.14.1",
     "pdfkit": "^0.8.3",
+    "remove-markdown": "^0.2.2",
     "request": "^2.83.0"
   }
 }


### PR DESCRIPTION
This PR:
- Removes '\r' characters from issue body which were not handled properly by `pdfkit`.
- Strips most markdown from issue body for PDF output (list leaders are maintained).