### PR TITLE
Add support for filtering issues by GitHub labels.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ $ node index.js --help
     -o, --owner [repo_owner]        The GitHub repo owner - username or org name
     -r, --repo [repo_name]          The GitHub repo name
     -m, --milestone [number]        (Optional) repo milestone number filter (from the GitHub URL)
+    -l, --labels [label_list]       Comma-separated list of labels to filter on
     --no-body                       Excludes the Issue body text
     -h, --help                      output usage information
 ```


### PR DESCRIPTION
This PR adds a `--label` option to allow filtering issues by GitHub labels. A CSV list of labels can be specified, in which case GitHub treats the labels as logical `AND` (all labels must match the issue).

Fixes https://github.com/jamiemjennings/github-issue-printer/issues/7