### PR TITLE
Set fixed height for issue title

### DIFF
--- a/lib/util/pdf.js
+++ b/lib/util/pdf.js
@@ -36,7 +36,7 @@ module.exports = {
       // back to regular opacity for header text
       pdfDoc.fillOpacity(1.0).fill('black')
       pdfDoc.font('Helvetica').fontSize(36).text(`${issueNum}: ${repoName}`).moveDown() // header title
-      pdfDoc.font('Helvetica').fontSize(72).lineGap(1).text(cardTitle) // main text
+      pdfDoc.font('Helvetica').fontSize(72).lineGap(1).text(cardTitle, {height: 200, ellipsis: '...'}) // main text
       pdfDoc.fontSize(8).moveDown()
       if (options.renderBody) {
         pdfDoc.font('Helvetica').fontSize(32).text(issue.body, {height: 250, ellipsis: '...'})


### PR DESCRIPTION
Set fixed height for issue title so that long issue titles don't push the content off the page.

Fixes #13 

**BEFORE**
![image](https://user-images.githubusercontent.com/6975957/37168407-d01c436e-22d2-11e8-99d8-77f680c78f4d.png)

**AFTER**
![image](https://user-images.githubusercontent.com/6975957/37169557-380b13a8-22d6-11e8-971b-72b2abf1a9bb.png)
